### PR TITLE
Fix : virgule en trop sur sql creation consigneproduct

### DIFF
--- a/sql/llx_consigne_consigneproduct.sql
+++ b/sql/llx_consigne_consigneproduct.sql
@@ -33,6 +33,6 @@ CREATE TABLE llx_consigne_consigneproduct(
 	est_emballage_consigne_vendu integer NOT NULL,
 	est_emballage_consigne_retour integer NOT NULL,
 	est_cache_bordereau_livraison integer DEFAULT 0 NOT NULL, 
-	colisage integer, 
+	colisage integer 
 	-- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;


### PR DESCRIPTION
Il y a une virgule en trop sur le dernier champs pour la création de la table `llx_consigne_consigneproduct`.